### PR TITLE
fix: keep Playwright shards alive in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,10 +55,15 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   // Retry on CI only
   retries: process.env.CI ? 2 : 0,
-  // Use more workers for better performance (1 in CI for stability, 4 locally for speed)
+  // Use one worker per shard in CI for predictable runtime.
   workers: process.env.CI ? 1 : 4,
-  // Reporter to use
-  reporter: 'html',
+  // Emit line output in CI so long shards don't get canceled for inactivity.
+  reporter: process.env.CI
+    ? [
+        ['line'],
+        ['html', { open: 'never' }],
+      ]
+    : 'html',
 
   use: {
     // Base URL for tests (html-site served on port 8000)


### PR DESCRIPTION
## Summary
- emit line reporter output in CI so long-running shards do not get canceled for inactivity
- keep one worker per shard in CI for predictable runtime

## Why
These Dependabot PRs are currently blocked by Playwright jobs that stall without console output long enough to be canceled.

Refs FreeForCharity/FFC-IN-ClarkeMoyerAdmin#42